### PR TITLE
Solve pthread lib issue on some OS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,3 +26,6 @@ endfunction()
 add_subdirectory(third_party)
 add_subdirectory(src)
 add_subdirectory(test)
+
+find_package(Threads)
+target_link_libraries (${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
Building on some OS (or with some compilers) may fail with pthread-undefined-reference error:
```
$ make lab1-debug
......
[ 97%] Linking CXX executable ../bin/shell
[ 98%] Linking CXX executable ../bin/server
[100%] Linking CXX executable ../bin/sqllogictest
/usr/bin/ld: CMakeFiles/server.dir/server.cpp.o: in function `std::thread::thread<void (&)(int, huadb::DatabaseEngine&), int&, std::reference_wrapper<huadb::DatabaseEngine>, void>(void (&)(int, huadb::DatabaseEngine&), int&, std::reference_wrapper<huadb::DatabaseEngine>&&)':
/usr/include/c++/9/thread:126: undefined reference to `pthread_create'
collect2: error: ld returned 1 exit status
make[3]: *** [src/CMakeFiles/server.dir/build.make:88: bin/server] Error 1
make[3]: Leaving directory 'huadb/build/debug'
make[2]: *** [CMakeFiles/Makefile2:642: src/CMakeFiles/server.dir/all] Error 2
make[2]: *** Waiting for unfinished jobs....
make[3]: Leaving directory 'huadb/build/debug'
[100%] Built target shell
make[3]: Leaving directory 'huadb/build/debug'
[100%] Built target sqllogictest
make[2]: Leaving directory 'huadb/build/debug'
make[1]: *** [Makefile:130: all] Error 2
make[1]: Leaving directory 'huadb/build/debug'
make: *** [Makefile:22: debug] Error 2
```

Modification of CMakeLists.txt solves this.